### PR TITLE
Fixed starredPosts object identifier subscript error

### DIFF
--- a/The Oakland Post/StarredPosts.swift
+++ b/The Oakland Post/StarredPosts.swift
@@ -15,10 +15,10 @@ class BugFixWrapper { // vars defined globally segfault the compiler in Xcode 6.
         didSet {
             // Compute starredPostIdentifiers.
             starredPostIdentifiers = [String]()
-            for object in starredPosts {
-                let ident = object["identifier"] as! String
-                starredPostIdentifiers.append(ident)
-            }
+			for object in starredPosts as! [PFObject] {
+				let ident = object.objectId
+				starredPostIdentifiers.append(ident!)
+			}
 
             // Sort self.
             starredPosts.sortInPlace {


### PR DESCRIPTION
When attempting to compile, an error stating that the subscript used to get a starredPosts object's identifier was ambiguous. This _should_ fix that. (Emphasis on should: I'm new to Cocoa/CocoaTouch, and am not sure how to setup Parse so I can login to test the starred posts feature). 

This way, the app at least compiles. I'm working on a [branch](https://github.com/peterkos/the-oakland-post/tree/swift-updates) to convert the rest of the deprecated Swift code, but those are only warnings. 
