### PR TITLE
Swift language deprecation updates

### DIFF
--- a/The Oakland Post/EnlargedPhotoGestureRecognizers.swift
+++ b/The Oakland Post/EnlargedPhotoGestureRecognizers.swift
@@ -22,10 +22,10 @@ class EnlargedPhotoGestureRecognizers: NSObject {
     func addToEnlargedPhoto(enlargedPhoto: EnlargedPhoto) {
         photo = enlargedPhoto
 
-        let tapGestureRecognizer = UITapGestureRecognizer(target: self, action: "singleTapReceived:")
-        let doubleTapGestureRecognizer = UITapGestureRecognizer(target: self, action: "doubleTapReceived:")
-        let swipeUpGestureRecognizer = UISwipeGestureRecognizer(target: self, action: "swipeReceived:")
-        let swipeDownGestureRecognizer = UISwipeGestureRecognizer(target: self, action: "swipeReceived:")
+        let tapGestureRecognizer = UITapGestureRecognizer(target: self, action: #selector(EnlargedPhotoGestureRecognizers.singleTapReceived(_:)))
+        let doubleTapGestureRecognizer = UITapGestureRecognizer(target: self, action: #selector(EnlargedPhotoGestureRecognizers.doubleTapReceived(_:)))
+        let swipeUpGestureRecognizer = UISwipeGestureRecognizer(target: self, action: #selector(EnlargedPhotoGestureRecognizers.swipeReceived(_:)))
+        let swipeDownGestureRecognizer = UISwipeGestureRecognizer(target: self, action: #selector(EnlargedPhotoGestureRecognizers.swipeReceived(_:)))
 
         doubleTapGestureRecognizer.numberOfTapsRequired = 2
         tapGestureRecognizer.requireGestureRecognizerToFail(doubleTapGestureRecognizer)

--- a/The Oakland Post/FavoritesViewController.swift
+++ b/The Oakland Post/FavoritesViewController.swift
@@ -13,7 +13,7 @@ class FavoritesViewController: BugFixTableViewController, StarButtonDelegate {
     private var didEnableButtonForPushers = false
 
     override func viewDidLoad() {
-        navigationItem.rightBarButtonItem = UIBarButtonItem(title: "Log Out", style: .Bordered, target: self, action: "logOut")
+        navigationItem.rightBarButtonItem = UIBarButtonItem(title: "Log Out", style: .Bordered, target: self, action: #selector(FavoritesViewController.logOut))
     }
 
     override func viewWillAppear(animated: Bool) {

--- a/The Oakland Post/HomeViewController.swift
+++ b/The Oakland Post/HomeViewController.swift
@@ -30,8 +30,8 @@ class HomeViewController: PostTableViewController, UISearchBarDelegate, TopScrol
 
         baseURL = "http://www.oaklandpostonline.com/search/?t=article"
 
-        logInBarButtonItem = UIBarButtonItem(title: "Log In", style: .Bordered, target: self, action: "logIn")
-        favoritesBarButtonItem = UIBarButtonItem(image: UIImage(named: "Favorites"), style: .Bordered, target: self, action: "showFavorites")
+        logInBarButtonItem = UIBarButtonItem(title: "Log In", style: .Bordered, target: self, action: #selector(HomeViewController.logIn))
+        favoritesBarButtonItem = UIBarButtonItem(image: UIImage(named: "Favorites"), style: .Bordered, target: self, action: #selector(HomeViewController.showFavorites))
 
         homeViewController = self
         if PFUser.currentUser() != nil {

--- a/The Oakland Post/InfoViewController.swift
+++ b/The Oakland Post/InfoViewController.swift
@@ -58,7 +58,7 @@ class InfoViewController: UIViewController, UIPageViewControllerDataSource {
         topToolbar.frame.size.height = topToolbarHeight
         view.addSubview(topToolbar)
 
-        let doneButton = UIBarButtonItem(title: "Done", style: .Done, target: self, action: "dismiss")
+        let doneButton = UIBarButtonItem(title: "Done", style: .Done, target: self, action: #selector(InfoViewController.dismiss))
         doneButton.tintColor = oaklandPostBlue
         topToolbar.items = [doneButton]
 

--- a/The Oakland Post/LoginViewController.swift
+++ b/The Oakland Post/LoginViewController.swift
@@ -26,7 +26,7 @@ class LoginViewController: UIViewController, UITextFieldDelegate, UIAlertViewDel
         super.viewDidLoad()
 
         navigationItem.rightBarButtonItem =
-            UIBarButtonItem(title: "Done", style: .Done, target: self, action: "dismiss:")
+            UIBarButtonItem(title: "Done", style: .Done, target: self, action: #selector(LoginViewController.dismiss(_:)))
 
         usernameTextField.delegate = self
         passwordTextField.delegate = self
@@ -51,9 +51,9 @@ class LoginViewController: UIViewController, UITextFieldDelegate, UIAlertViewDel
 
     func registerForKeyboardNotifications() {
         NSNotificationCenter.defaultCenter().addObserver(
-            self, selector: "keyboardDidShow:", name: UIKeyboardDidShowNotification, object: nil)
+            self, selector: #selector(LoginViewController.keyboardDidShow(_:)), name: UIKeyboardDidShowNotification, object: nil)
         NSNotificationCenter.defaultCenter().addObserver(
-            self, selector: "keyboardWillHide:", name: UIKeyboardWillHideNotification, object: nil)
+            self, selector: #selector(LoginViewController.keyboardWillHide(_:)), name: UIKeyboardWillHideNotification, object: nil)
     }
 
     func keyboardDidShow(notification: NSNotification) {
@@ -91,7 +91,7 @@ class LoginViewController: UIViewController, UITextFieldDelegate, UIAlertViewDel
     var count = 0
     override func viewDidLayoutSubviews() {
         super.viewDidLayoutSubviews()
-        if (++count == 2) {
+        if (count.advancedBy(1) == 2) {
             let viewHeight = view.frame.size.height
             let viewWidth = view.frame.size.width
             var navBarHeight = navigationController!.navigationBar.frame.size.height

--- a/The Oakland Post/PhotosViewController.swift
+++ b/The Oakland Post/PhotosViewController.swift
@@ -118,7 +118,7 @@ class PhotosViewController: UICollectionViewController, UICollectionViewDelegate
         }
         enlargedPhoto!.scrollView.delegate = enlargedPhotoDelegate
 
-        enlargedPhoto!.linkButton.addTarget(self, action: "showPost:", forControlEvents: .TouchUpInside)
+        enlargedPhoto!.linkButton.addTarget(self, action: #selector(PhotosViewController.showPost(_:)), forControlEvents: .TouchUpInside)
         gestureRecognizers.addToEnlargedPhoto(enlargedPhoto!)
 
         navigationController!.view.addSubview(enlargedPhoto!)
@@ -151,7 +151,7 @@ class PhotosViewController: UICollectionViewController, UICollectionViewDelegate
             let themedNavigationController = (segue.destinationViewController as! ThemedNavigationController)
             let postViewController = (themedNavigationController.childViewControllers[0] as! PostViewController)
             postViewController.navigationItem.rightBarButtonItem =
-                UIBarButtonItem(title: "Done", style: .Done, target: self, action: "dismissModalPost")
+                UIBarButtonItem(title: "Done", style: .Done, target: self, action: #selector(PhotosViewController.dismissModalPost))
             postViewController.URL = URLs[(sender as! NSNumber).integerValue]
         }
     }

--- a/The Oakland Post/PostTableViewController.swift
+++ b/The Oakland Post/PostTableViewController.swift
@@ -22,7 +22,7 @@ class PostTableViewController: BugFixTableViewController, MWFeedParserDelegate, 
 
         // Pull to refresh.
         let refreshControl = UIRefreshControl()
-        refreshControl.addTarget(self, action: "refresh", forControlEvents: UIControlEvents.ValueChanged)
+        refreshControl.addTarget(self, action: #selector(PostTableViewController.refresh), forControlEvents: UIControlEvents.ValueChanged)
         self.refreshControl = refreshControl
 
         feedParser = FeedParser(baseURL: baseURL, length: 15, delegate: self)

--- a/The Oakland Post/PostViewController.swift
+++ b/The Oakland Post/PostViewController.swift
@@ -69,11 +69,11 @@ class PostViewController: UIViewController, UIWebViewDelegate, UIScrollViewDeleg
     }
 
     func webView(webView: UIWebView, didFailLoadWithError error: NSError?) {
-        --loadCount
+        loadCount -= 1
     }
 
     func webViewDidStartLoad(webView: UIWebView) {
-        if ++loadCount == 1 {
+        if (loadCount.advancedBy(1)) == 1 {
             UIApplication.sharedApplication().networkActivityIndicatorVisible = true
             SVProgressHUD.show()
         }
@@ -82,7 +82,7 @@ class PostViewController: UIViewController, UIWebViewDelegate, UIScrollViewDeleg
     // MARK: UIWebViewDelegate
 
     func webViewDidFinishLoad(webView: UIWebView) {
-        --loadCount
+        loadCount -= 1
         if loadCount == 0 {
             finishedLoading = true
 

--- a/The Oakland Post/PushViewController.swift
+++ b/The Oakland Post/PushViewController.swift
@@ -19,7 +19,7 @@ class PushViewController: UIViewController, UIAlertViewDelegate {
     @IBOutlet weak var bottomLayoutConstraint: NSLayoutConstraint!
 
     override func viewDidLoad() {
-        let sendButton = UIBarButtonItem(title: "Send", style: .Done, target: self, action: "confirmPush")
+        let sendButton = UIBarButtonItem(title: "Send", style: .Done, target: self, action: #selector(PushViewController.confirmPush))
         sendButton.enabled = false
         textView.editable = false
         textView.selectable = false
@@ -103,9 +103,9 @@ class PushViewController: UIViewController, UIAlertViewDelegate {
 
     func registerForKeyboardNotifications() {
         NSNotificationCenter.defaultCenter().addObserver(
-            self, selector: "keyboardDidShow:", name: UIKeyboardDidShowNotification, object: nil)
+            self, selector: #selector(PushViewController.keyboardDidShow(_:)), name: UIKeyboardDidShowNotification, object: nil)
         NSNotificationCenter.defaultCenter().addObserver(
-            self, selector: "keyboardWillHide:", name: UIKeyboardWillHideNotification, object: nil)
+            self, selector: #selector(PushViewController.keyboardWillHide(_:)), name: UIKeyboardWillHideNotification, object: nil)
     }
 
     func keyboardDidShow(notification: NSNotification) {

--- a/The Oakland Post/SignUpViewController.swift
+++ b/The Oakland Post/SignUpViewController.swift
@@ -28,7 +28,7 @@ class SignUpViewController: UIViewController, UITextFieldDelegate {
         super.viewDidLoad()
 
         navigationItem.rightBarButtonItem =
-            UIBarButtonItem(title: "Done", style: .Done, target: self, action: "dismiss")
+            UIBarButtonItem(title: "Done", style: .Done, target: self, action: #selector(SignUpViewController.dismiss))
 
         usernameTextField.delegate = self
         passwordTextField.delegate = self
@@ -60,9 +60,9 @@ class SignUpViewController: UIViewController, UITextFieldDelegate {
 
     func registerForKeyboardNotifications() {
         NSNotificationCenter.defaultCenter().addObserver(
-            self, selector: "keyboardDidShow:", name: UIKeyboardDidShowNotification, object: nil)
+            self, selector: #selector(SignUpViewController.keyboardDidShow(_:)), name: UIKeyboardDidShowNotification, object: nil)
         NSNotificationCenter.defaultCenter().addObserver(
-            self, selector: "keyboardWillHide:", name: UIKeyboardWillHideNotification, object: nil)
+            self, selector: #selector(SignUpViewController.keyboardWillHide(_:)), name: UIKeyboardWillHideNotification, object: nil)
     }
 
     var insets = UIEdgeInsetsZero
@@ -98,10 +98,10 @@ class SignUpViewController: UIViewController, UITextFieldDelegate {
         scrollView.scrollIndicatorInsets = insets
     }
 
-    var count = 0
+	var count: Int = 0
     override func viewDidLayoutSubviews() {
         super.viewDidLayoutSubviews()
-        if ++count == 2 || (count == 4 && keyboardWasPresent) {
+        if count.advancedBy(1) == 2 || (count == 4 && keyboardWasPresent) {
             let viewHeight = view.frame.size.height
             let viewWidth = view.frame.size.width
             var navBarHeight = navigationController!.navigationBar.frame.size.height

--- a/The Oakland Post/StarredPosts.swift
+++ b/The Oakland Post/StarredPosts.swift
@@ -15,10 +15,10 @@ class BugFixWrapper { // vars defined globally segfault the compiler in Xcode 6.
         didSet {
             // Compute starredPostIdentifiers.
             starredPostIdentifiers = [String]()
-            for object in starredPosts {
-                let ident = object["identifier"] as! String
-                starredPostIdentifiers.append(ident)
-            }
+			for object in starredPosts as! [PFObject] {
+				let ident = object.objectId
+				starredPostIdentifiers.append(ident!)
+			}
 
             // Sort self.
             starredPosts.sortInPlace {


### PR DESCRIPTION
Fixed issues that will arise once Swift 3 is released, mainly relating to:
1. [Removal of ++ and -- operators](https://github.com/apple/swift-evolution/blob/master/proposals/0004-remove-pre-post-inc-decrement.md)
   - `--loadCount` becomes `loadCount -= 1`
2. Use of string literal for Objective-C Selectors
   - `let tapGestureRecognizer = UITapGestureRecognizer(target: self, action: "singleTapReceived:")`
     becomes  
     `let tapGestureRecognizer = UITapGestureRecognizer(target: self, action: #selector(EnlargedPhotoGestureRecognizers.singleTapReceived(_:)))`
